### PR TITLE
We need to test for the case where context has...

### DIFF
--- a/src/RuleProcessor.coffee
+++ b/src/RuleProcessor.coffee
@@ -3,7 +3,7 @@ class RuleProcessor
 
   rule:
     name: 'no_mocha_only'
-    description: 'Validates there are no describe.only or it.only calls'
+    description: 'Validates there are no context.only, describe.only or it.only calls'
     level: 'error'
     message: '.only not allowed'
 
@@ -13,6 +13,8 @@ class RuleProcessor
       return context: 'Unexpected it.only'
     if /describe\.only/.test line
       return context: 'Unexpected describe.only'
+    if /context\.only/.test line
+      return context: 'Unexpected context.only'
     else return null
 
 module.exports = RuleProcessor

--- a/test/RuleProcessor.test.coffee
+++ b/test/RuleProcessor.test.coffee
@@ -23,6 +23,14 @@ describe 'RuleProcessor', () ->
     result = processor.lintLine '', fakeAPI
     should.not.exist result
 
+  it 'should trigger on context.only if required', () ->
+    result = processor.lintLine 'context.only ->', fakeAPI
+    result.should.have.property 'context'
+
+  it 'should not trigger on lines with no context.only if required', () ->
+    result = processor.lintLine '', fakeAPI
+    should.not.exist result
+
   it 'should trigger on it.only if required', () ->
     result = processor.lintLine 'it.only ->', fakeAPI
     result.should.have.property 'context'


### PR DESCRIPTION
...`.only` as well. Unfortunately, this case wasn't supported by this package, but is
something that we do in our codebase.
